### PR TITLE
Implement API route to return a specific Skill

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,6 +91,11 @@ def skill():
     Handles Skill requests
     '''
     if request.method == 'GET':
+        index = request.args.get("index")
+        if index:
+            if index.isdigit() and 0 <= int(index) < len(data["skill"]):
+                return jsonify(data["skill"][int(index)])
+            return jsonify({"message": "Invalid index"}), 400
         return jsonify(data.get('skill', []))
 
     if request.method == 'POST':

--- a/app.py
+++ b/app.py
@@ -85,31 +85,33 @@ def education():
     return jsonify({"message":"Inavlid method"}), 405
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
-def skill():
+@app.route('/resume/skill', methods=['GET'])
+def get_skill():
     '''
-    Handles Skill requests
+    Handles GET skill requests
     '''
-    if request.method == 'GET':
-        index = request.args.get("index")
-        if index:
-            if index.isdigit() and 0 <= int(index) < len(data["skill"]):
-                return jsonify(data["skill"][int(index)])
-            return jsonify({"message": "Invalid index"}), 400
-        return jsonify(data.get('skill', []))
+    index = request.args.get("id")
+    if index:
+        if index.isdigit() and 0 <= int(index) < len(data["skill"]):
+            return jsonify(data["skill"][int(index)])
+        return jsonify({"message": "Invalid index"}), 400
+    return jsonify(data.get('skill', []))
 
-    if request.method == 'POST':
-        required_fields = ['name', 'proficiency', 'logo']
-        if not request.json:
-            return jsonify({"message": "Request body must be JSON"}), 400
-        for field in required_fields:
-            if field not in request.json:
-                return jsonify({"message": f"Your request is missing {field}."}), 400
 
-        new_skill = Skill(request.json['name'],
-                            request.json['proficiency'],
-                            request.json['logo'])
-        data['skill'].append(new_skill)
-        return jsonify({"id": len(data['skill']) - 1})
+@app.route('/resume/skill', methods=['POST'])
+def post_skill():
+    '''
+    Handles POST skill requests
+    '''
+    required_fields = ['name', 'proficiency', 'logo']
+    if not request.json:
+        return jsonify({"message": "Request body must be JSON"}), 400
+    for field in required_fields:
+        if field not in request.json:
+            return jsonify({"message": f"Your request is missing {field}."}), 400
 
-    return jsonify({"message": "This Route only supports GET & POST"}), 405
+    new_skill = Skill(request.json['name'],
+                        request.json['proficiency'],
+                        request.json['logo'])
+    data['skill'].append(new_skill)
+    return jsonify({"id": len(data['skill']) - 1})


### PR DESCRIPTION
- Added the route `GET /resume/skill?id=<skill_index>`
    -  If the index is valid, the endpoint returns the specific skill at that index
    -   Otherwise, it returns a 400 error with the message Invalid index.
    
 - Split up the `GET` and `POST` method handling for the route  `/resume/skill` into two separate functions to fix the "too many return statements" linting error.

Closes #14 