### PR TITLE
Edit experience

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,31 @@ def experience():
     return jsonify({"message": "Invalid method"}), 405
 
 
+@app.route('/resume/experience/<index>', methods=['PUT'])
+def put_experience(index):
+    '''
+    Handle experience PUT requests
+    Returns the updated experience resource
+    '''
+    # Check that a valid index was provided
+    if not index.isdigit() or int(index) < 0 or int(index) >= len(data["experience"]):
+        return jsonify({"message": "Invalid id"}), 400
+
+    index = int(index)
+    content = request.get_json()
+
+    # Check that a valid body was provided
+    if not request.json:
+        return jsonify({"message": "Request body must be JSON"}), 400
+
+    # Update each field for the experience at the given index
+    for field in content.keys():
+        if content[field]:
+            setattr(data["experience"][index], field, content[field])
+
+    return jsonify(data["experience"][index]), 200
+
+
 @app.route('/resume/education', methods=['GET'])
 def get_education():
     '''

--- a/app.py
+++ b/app.py
@@ -30,6 +30,8 @@ data = {
     ]
 }
 
+experience_required_fields = set(["title", "company", "start_date",
+                                  "end_date", "description", "logo"])
 
 @app.route('/test')
 def hello_world():
@@ -55,8 +57,7 @@ def experience():
 
     if request.method == 'POST':
         content = request.get_json()
-        required_fields = ["title", "company", "start_date", "end_date", "description", "logo"]
-        if not content or any(field not in content for field in required_fields):
+        if not content or any(field not in content for field in experience_required_fields):
             return jsonify({"message": "Missing required fields"}), 400
         data["experience"].append(Experience(**content))
         return jsonify({"id": len(data["experience"]) - 1}), 201
@@ -83,7 +84,7 @@ def put_experience(index):
 
     # Update each field for the experience at the given index
     for field in content.keys():
-        if content[field]:
+        if content[field] and field in experience_required_fields:
             setattr(data["experience"][index], field, content[field])
 
     return jsonify(data["experience"][index]), 200

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -34,6 +34,28 @@ def test_experience():
     assert response.json[item_id] == example_experience
 
 
+def test_put_experience():
+    '''
+    Add a new experience, update a field in the experience, then get all experiences. 
+    
+    Check that it returns the updated experience in that list
+    '''
+    example_experience = {
+        "title": "Software Developer",
+        "company": "A Cooler Company",
+        "start_date": "October 2022",
+        "end_date": "Present",
+        "description": "Writing JavaScript Code",
+        "logo": "example-logo.png"
+    }
+    item_id = app.test_client().post('/resume/experience',
+                                     json=example_experience).json['id']
+    new_experience = app.test_client().put('/resume/experience/'+str(item_id),
+                                           json={"end_date": "October 2023"}).json
+    response = app.test_client().get('/resume/experience')
+    assert response.json[item_id] == new_experience
+
+
 def test_education():
     '''
     Add a new education and then get all educations. 


### PR DESCRIPTION
- Added the route `PUT /resume/experience/<experience_index>`
    - If the given index is invalid or the request does not contain a JSON body, the endpoint returns `400`.
    - Otherwise, the each provided field in the experience is updated, then the updated experience is returned with a code `200`
- Added a test to check that an experience can be edited

Closes #8 .