### PR TITLE
Validate POST Requests & Add tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,23 @@ data = {
 experience_required_fields = set(["title", "company", "start_date",
                                   "end_date", "description", "logo"])
 
+education_required_fields = set(["course", "school", "start_date",
+                                 "end_date", "grade", "logo"])
+
+skill_required_fields = set(["name", "proficiency", "logo"])
+
+# Function to dynamically check required fields and build
+# a response with all the missing required fields
+def check_fields(data, required_fields):
+    '''
+    Check if all the required fields are present in the given data dictionary.
+    '''
+    # missing_fields is grounded on required_fields
+    missing_fields = required_fields - set(data.keys())
+    if missing_fields:
+        return jsonify({"message": f"Missing required fields: {missing_fields}"}), 400
+    return None
+
 @app.route('/test')
 def hello_world():
     '''
@@ -57,8 +74,9 @@ def experience():
 
     if request.method == 'POST':
         content = request.get_json()
-        if not content or any(field not in content for field in experience_required_fields):
-            return jsonify({"message": "Missing required fields"}), 400
+        bad_fields = check_fields(content, experience_required_fields)
+        if bad_fields:
+            return bad_fields
         data["experience"].append(Experience(**content))
         return jsonify({"id": len(data["experience"]) - 1}), 201
 
@@ -110,6 +128,9 @@ def post_education():
     '''
     if request.get_json():
         education_data = request.get_json()
+        bad_fields = check_fields(education_data, education_required_fields)
+        if bad_fields:
+            return bad_fields
         for value in education_data.values():
             if value is None:
                 return jsonify({"message":"Mandatory fields are missing"}), 400
@@ -136,12 +157,12 @@ def post_skill():
     '''
     Handles POST skill requests
     '''
-    required_fields = ['name', 'proficiency', 'logo']
     if not request.json:
         return jsonify({"message": "Request body must be JSON"}), 400
-    for field in required_fields:
-        if field not in request.json:
-            return jsonify({"message": f"Your request is missing {field}."}), 400
+    
+    bad_fields = check_fields(request.json, skill_required_fields)
+    if bad_fields:
+        return bad_fields
 
     new_skill = Skill(request.json['name'],
                         request.json['proficiency'],

--- a/app.py
+++ b/app.py
@@ -40,12 +40,12 @@ skill_required_fields = set(["name", "proficiency", "logo"])
 
 # Function to dynamically check required fields and build
 # a response with all the missing required fields
-def check_fields(data, required_fields):
+def check_fields(incoming_data, required_fields):
     '''
     Check if all the required fields are present in the given data dictionary.
     '''
     # missing_fields is grounded on required_fields
-    missing_fields = required_fields - set(data.keys())
+    missing_fields = required_fields - set(incoming_data.keys())
     if missing_fields:
         return jsonify({"message": f"Missing required fields: {missing_fields}"}), 400
     return None
@@ -190,7 +190,6 @@ def post_skill():
     '''
     if not request.json:
         return jsonify({"message": "Request body must be JSON"}), 400
-    
     bad_fields = check_fields(request.json, skill_required_fields)
     if bad_fields:
         return bad_fields

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -94,3 +94,53 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+
+def test_skill_missing_data():
+    '''
+    Add a new skill with missing data and check that
+    it returns a 400 error
+    '''
+    example_skill = {
+        "proficiency": "2-4 years",
+        "logo": "example-logo.png"
+    }
+
+    response = app.test_client().post('/resume/skill',
+                                      json=example_skill)
+    assert response.status_code == 400
+
+
+def test_education_missing_data():
+    '''
+    Add a new education with missing data and check that
+    it returns a 400 error
+    '''
+    example_education = {
+        "course": "Engineering",
+        "school": "NYU",
+        "start_date": "October 2022",
+        "logo": "example-logo.png"
+    }
+
+    response = app.test_client().post('/resume/education',
+                                      json=example_education)
+    assert response.status_code == 400
+
+
+def test_experience_missing_data():
+    '''
+    Add a new experience with missing data and check that
+    it returns a 400 error
+    '''
+    example_experience = {
+        "title": "Software Developer",
+        "company": "A Cooler Company",
+        "start_date": "October 2022",
+        "description": "Writing JavaScript Code",
+        "logo": "example-logo.png"
+    }
+
+    response = app.test_client().post('/resume/experience',
+                                      json=example_experience)
+    assert response.status_code == 400


### PR DESCRIPTION
## Validate the POST requests to Experience, Education, and Skill
 - Created a function `check_fields` to simplify field checking for all routes and provide a complete return message
   - Now, all fields that are missing are going to be returned to the user so they can send a proper request.
  - routes `/resume/experience`, `/resume/education`, `/resume/skill`
## Created new test cases to check behavior for missing data
  - New tests: `test_skill_missing_data`, `test_education_missing_data`, `test_experience_missing_data`.

- Tackles #13 